### PR TITLE
Undefined call

### DIFF
--- a/lib/no-gyp-xml-stream.js
+++ b/lib/no-gyp-xml-stream.js
@@ -93,11 +93,13 @@ NoGypXmlStream.getChildrenFromSaxStream = function(parentName, childName, saxStr
                 }
             }
             if(!opts.flatten || dontFlatten){ //Don't flatten, always use attr and text vars and arrays everywhere
-                if(!elemp[nodeName]){
-                    elemp[nodeName] = [];
+                if(elemp){
+                    if(!elemp[nodeName]){
+                        elemp[nodeName] = [];
+                    }
+                    elemp[nodeName].push(elemc);
+                    elementStack.push(elemp);
                 }
-                elemp[nodeName].push(elemc);
-                elementStack.push(elemp);
             }
             else{
                 //Flatten text if it's the only value


### PR DESCRIPTION
Variable elemp is sometimes used when it's undefined. Because of this, we need to check it.